### PR TITLE
chore: update version to 1.5.3 and change RKE2 release URL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 BINARY_NAME=seactl
-VERSION ?= 1.5.2
+VERSION ?= 1.5.3
 LDFLAGS = -ldflags "-X main.version=$(VERSION)"
 
 build:

--- a/pkg/rke2/rke2.go
+++ b/pkg/rke2/rke2.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	RKE2ReleaseURL = "https://github.com/rancher/rke2/releases/download/"
+	RKE2ReleaseURL = "https://prime.ribs.rancher.io/rke2/"
 	RKE2URL        = "https://get.rke2.io"
 )
 


### PR DESCRIPTION
This pull request makes a minor update to the project, including a version bump and a change to the RKE2 release URL. These changes ensure the project references the correct release location and reflects the new version.

Version and URL updates:

* Updated the project version from `1.5.2` to `1.5.3` in the `Makefile`.
* Changed the `RKE2ReleaseURL` in `pkg/rke2/rke2.go` to use `https://prime.ribs.rancher.io/rke2/` instead of the previous GitHub releases URL.